### PR TITLE
VV-2986 Also stop the peekBoundary() loop in nextField() when the pee…

### DIFF
--- a/src/HTTPMultipartBodyParser.cpp
+++ b/src/HTTPMultipartBodyParser.cpp
@@ -169,10 +169,14 @@ bool HTTPMultipartBodyParser::peekBoundary() {
 
 int32_t HTTPMultipartBodyParser::nextField() {
   fillBuffer(MAXLINESIZE);
-  while(!peekBoundary()) {
+  while (!peekBoundary()) {
+    if (peekBufferSize == 0) {
+      HTTPS_LOGE("Multipart missing last boundary1");
+      return -1;
+    }
     std::string dummy = readLine();
     if (endOfBody()) {
-      HTTPS_LOGE("Multipart missing last boundary");
+      HTTPS_LOGE("Multipart missing last boundary2");
       return -1;
     }
     fillBuffer(MAXLINESIZE);


### PR DESCRIPTION
**Changes:**
- Also stop the peekBoundary() loop in nextField() when the peekBufferSize==0

**Tested:**
- Functional tested on a DN, the watchdog timeout was not observed for more than 3 days
