### PR TITLE
VV-3453 Only discard request body when necessary

### DIFF
--- a/src/HTTPConnection.cpp
+++ b/src/HTTPConnection.cpp
@@ -515,9 +515,10 @@ void HTTPConnection::loop() {
           next();
 
           // The callback-function should have read all of the request body.
-          // However, if it does not, we need to clear the request body now,
-          // because otherwise it would be parsed in the next request.
-          if (!req.requestComplete()) {
+          // However, if it does not and we want to reuse the connection, we
+          // need to clear the request body now, because otherwise it would
+          // be parsed in the next request.
+          if (!req.requestComplete() && _isKeepAlive) {
             HTTPS_LOGW("Callback function did not parse full request body");
             req.discardRequestBody();
           }

--- a/src/HTTPConnection.cpp
+++ b/src/HTTPConnection.cpp
@@ -177,9 +177,6 @@ int HTTPConnection::updateBuffer() {
 
     if (_bufferUnusedIdx < HTTPS_CONNECTION_DATA_CHUNK_SIZE) {
       if (canReadData()) {
-
-        HTTPS_LOGD("Data on Socket FID=%d", _socket);
-
         int readReturnCode;
 
         // The return code of SSL_read means:

--- a/src/HTTPMultipartBodyParser.cpp
+++ b/src/HTTPMultipartBodyParser.cpp
@@ -20,7 +20,7 @@ HTTPMultipartBodyParser::HTTPMultipartBodyParser(HTTPRequest * req):
   auto boundaryIndex = contentType.find("boundary=");
   if(boundaryIndex == std::string::npos) {
     HTTPS_LOGE("Multipart: missing boundary=");
-    discardBody();
+    resetBuffer();
     return;
   }
   boundary = contentType.substr(boundaryIndex + 9); // "boundary="
@@ -28,7 +28,7 @@ HTTPMultipartBodyParser::HTTPMultipartBodyParser(HTTPRequest * req):
   boundary = "--" + boundary.substr(0, commaIndex);
   if(boundary.size() > 72) {
     HTTPS_LOGE("Multipart: boundary string too long");
-    discardBody();
+    resetBuffer();
   }
   lastBoundary = boundary + "--";
 }
@@ -40,13 +40,12 @@ HTTPMultipartBodyParser::~HTTPMultipartBodyParser() {
   }
 }
 
-void HTTPMultipartBodyParser::discardBody() {
+void HTTPMultipartBodyParser::resetBuffer() {
   if (peekBuffer) {
     free(peekBuffer);
   }
   peekBuffer = NULL;
   peekBufferSize = 0;
-  _request->discardRequestBody();
 }
 
 bool HTTPMultipartBodyParser::endOfBody() {
@@ -65,7 +64,7 @@ void HTTPMultipartBodyParser::fillBuffer(size_t maxLen) {
     peekBuffer = (char *)malloc(maxLen);
     if (peekBuffer == NULL) {
       HTTPS_LOGE("Multipart: out of memory");
-      discardBody();
+      resetBuffer();
       return;
     }
     bufPtr = peekBuffer;
@@ -75,7 +74,7 @@ void HTTPMultipartBodyParser::fillBuffer(size_t maxLen) {
     char *newPeekBuffer = (char *)realloc(peekBuffer, maxLen);
     if (newPeekBuffer == NULL) {
       HTTPS_LOGE("Multipart: out of memory");
-      discardBody();
+      resetBuffer();
       return;
     }
     peekBuffer = newPeekBuffer;
@@ -127,7 +126,7 @@ bool HTTPMultipartBodyParser::skipCRLF() {
   }
   if (peekBuffer[1] != '\n') {
     HTTPS_LOGE("Multipart incorrect line terminator");
-    discardBody();
+    resetBuffer();
     return false;
   }
   consumedBuffer(2);
@@ -142,7 +141,7 @@ std::string HTTPMultipartBodyParser::readLine() {
   char *crPtr = (char *)memchr(peekBuffer, '\r', peekBufferSize);
   if (crPtr == NULL) {
     HTTPS_LOGE("Multipart line too long");
-    discardBody();
+    resetBuffer();
     return "";
   }
   size_t lineLength = crPtr-peekBuffer;
@@ -184,7 +183,7 @@ int32_t HTTPMultipartBodyParser::nextField() {
   skipCRLF();
   std::string line = readLine();
   if (line == lastBoundary) {
-    discardBody();
+    resetBuffer();
     return 0;
   }
   if (line != boundary) {

--- a/src/HTTPMultipartBodyParser.hpp
+++ b/src/HTTPMultipartBodyParser.hpp
@@ -22,7 +22,7 @@ private:
   void consumedBuffer(size_t consumed);
   bool skipCRLF();
   bool peekBoundary();
-  void discardBody();
+  void resetBuffer();
   bool endOfBody();
   char *peekBuffer;
   size_t peekBufferSize;


### PR DESCRIPTION
Changes:
- Removed call to `HTTPRequest::discardRequestBody` from `HTTPMultipartBodyParser::discardBody`
  - The `HTTPConnection` class already checks if a request has been consumed fully after the parser is done so this was redundant.
- Renamed  `HTTPMultipartBodyParser::discardBody` to  `HTTPMultipartBodyParser::resetBuffer` as it now no longer actually discards the body but only resets some buffer related variables.
- The request body is now only discarded if the connection is meant to be reused. This is controlled by the `Connection` header in the response.